### PR TITLE
remove "Macros" section from "Future possibilities"

### DIFF
--- a/text/0000-anonymous-enums.md
+++ b/text/0000-anonymous-enums.md
@@ -313,36 +313,3 @@ where
 Where `x` is some limit, like `32` for arrays or `12` for tuples.
 
 By "simple" I mean "object safe" and without generics/associated types.
-
-## Macros // TODO: more clear topic
-
-Extend `macro_rules!` syntax so this would be possible:
-
-```rust
-pub trait Id {
-    type Id: ?Sized;
-}
-
-impl<T: ?Sized> Id for T {
-    type Id = T;
-}
-
-pub const fn type_eq::<A, B>() 
-where
-    A: Id<Id = B>,
-{}
-
-macro_rules! enum_to_tuple {
-    ( $( $T:ty )|+ ) => ( $( $T ),+ );
-}
-
-macro_rules! tuple_to_enum {
-    ( $( $T:ty ),+ ) => ( $( $T )|+ );
-}
-
-struct A; struct B; struct C;
-
-const _: () = {
-    type_eq::<enum_to_tuple!(A | B | C), (A, B, C)>();
-    type_eq::<tuple_to_enum!(A, B, C), A | B | C>();
-};


### PR DESCRIPTION
Remove "Macros" section from "Future possibilities" because it's already
possible without any syntax extensions:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=5fd4bf9ee4bcb888314feeeb286407cc